### PR TITLE
update cmake for qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,13 +11,28 @@ include(FeatureSummary)
 include(GNUInstallDirs)
 
 set(QT_MIN_VERSION "5.12.0")
-find_package(Qt5 COMPONENTS Core Qml Quick DBus LinguistTools REQUIRED)
+
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core Qml Quick DBus LinguistTools )
+    find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core Qml Quick DBus LinguistTools REQUIRED)
+
+
+if(${QT_VERSION} VERSION_LESS "5.15.0")
+    macro(qt_add_translation)
+        qt5_add_translation(${ARGN})
+    endmacro()
+    macro(qt_add_resources)
+        qt5_add_resources(${ARGN})
+    endmacro()
+    macro(qt_add_dbus_interface)
+        qt5_add_dbus_interface(${ARGN})
+    endmacro()
+endif()
 
 add_subdirectory(src)
 
 # Translations
 file(GLOB TS_FILES translations/*.ts)
-qt5_add_translation(QM_FILES ${TS_FILES})
+qt_add_translation(QM_FILES ${TS_FILES})
 add_custom_target(translations DEPENDS ${QM_FILES})
 add_dependencies(nemofingerprint translations)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,15 @@
 ### Sets QT_INSTALL_QML to the directory where QML Plugins should be installed
 function(FindQtInstallQml)
-    find_program(QMAKE NAMES qmake-qt5 qmake)
+    if (QT_VERSION_MAJOR EQUAL 5)
+        find_program(QMAKE NAMES qmake-qt5 qmake)
+    elseif (QT_VERSION_MAJOR EQUAL 6)
+        find_program(QMAKE NAMES qmake-qt6 qmake6)
+    else()
+        message(FATAL_ERROR "incorrect QT_VERSION_MAJOR")
+    endif ()
+
     if(NOT QMAKE)
-    message(FATAL_ERROR "qmake not found")
+        message(FATAL_ERROR "qmake not found")
     endif()
     execute_process(
         COMMAND ${QMAKE} -query QT_INSTALL_QML
@@ -29,12 +36,12 @@ set(HEADERS
     fingerprintdevice.h
     fingerprintmodel.h)
 
-qt5_add_dbus_interface(nemo_fingerptint_SRCS
+qt_add_dbus_interface(nemo_fingerptint_SRCS
     net.reactivated.Fprint.Device.xml
     fprint_device_interface
 )
 
-qt5_add_dbus_interface(nemo_fingerptint_SRCS
+qt_add_dbus_interface(nemo_fingerptint_SRCS
     net.reactivated.Fprint.Manager.xml
     fprint_manager_interface
 )
@@ -42,10 +49,10 @@ qt5_add_dbus_interface(nemo_fingerptint_SRCS
 add_library(nemofingerprint SHARED ${nemo_fingerptint_SRCS} ${HEADERS})
 
 target_link_libraries(nemofingerprint
-    Qt5::Core
-    Qt5::Qml 
-    Qt5::Quick
-    Qt5::DBus)
+    Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::Qml
+    Qt${QT_VERSION_MAJOR}::Quick
+    Qt${QT_VERSION_MAJOR}::DBus)
 
 FindQtInstallQml()
 


### PR DESCRIPTION
Something seems to be broken. The compilation reports. Not sure if it is related to Qt6 or was there already before

```
/usr/lib/qt6/bin/qdbusxml2cpp -N -m -p fprint_device_interface /home/jmlich/workspace/nemo-qml-plugin-fingerprint/src/net.reactivated.Fprint.Device.xml
dbus.parser: Invalid D-BUS object path '//' found while parsing introspection
dbus.parser: Unknown element "doc" while checking for signal arguments
dbus.parser: Unknown element "doc" while checking for signal arguments
dbus.parser: Unknown element "doc" while checking for signal arguments
dbus.parser: Invalid D-BUS member name 'num-enroll-stages' found in interface 'net.reactivated.Fprint.Device' while parsing introspection
dbus.parser: Invalid D-BUS member name 'scan-type' found in interface 'net.reactivated.Fprint.Device' while parsing introspection
dbus.parser: Invalid D-BUS member name 'finger-present' found in interface 'net.reactivated.Fprint.Device' while parsing introspection
dbus.parser: Invalid D-BUS member name 'finger-needed' found in interface 'net.reactivated.Fprint.Device' while parsing introspection
```